### PR TITLE
[Modify] css값 일부 수정 및 post template에서도 dark mode 조절할 수 있도록 컴포넌트 추가

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,12 +1,10 @@
 body {
     --color-background:#f6f6f6;
-    --color-text: black;
 }
 
 .dark {
     --color-background: #393E46;
     --color-text: #f6f6f6;
-    --color-hover: #ece75f
 }
 
 body{

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -6,6 +6,7 @@ import PostHead from 'components/Post/PostHead'
 import PostContent from 'components/Post/PostContent'
 import CommentWidget from 'components/Post/CommentWidget'
 import ScrollToTop from 'components/Common/ScrollToTop'
+import HeaderTheme from 'components/Common/HeaderTheme'
 
 type PostTemplateProps = {
   data: {
@@ -48,6 +49,7 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
         categories={categories}
         thumbnail={gatsbyImageData}
       />
+      <HeaderTheme />
       <PostContent html={html} />
       <CommentWidget />
       <ScrollToTop />


### PR DESCRIPTION
## Backgrounds
- 코드블록에서 매개변수의 색깔이 다크모드일때 검정색으로 보이는 이슈 핸들링
- 포스팅을 읽던 중, 다크 모드 <-> 라이트 모드 전환을 빠르게 접근할 수 있도록 토글 컴포넌트 추가 

## Changes 
- `theme.css` 에서 일부 css 값 및 필요없는 값 제거 
- `post_template`에 토글 버튼 추가