### PR TITLE
feat : prev/next button

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,6 +56,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
                 slug
               }
             }
+            next {
+              fields {
+                slug
+              }
+            }
+            previous {
+              fields {
+                slug
+              }
+            }
           }
         }
       }
@@ -81,23 +91,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         fields: { slug },
       },
     },
-    index,
   ) => {
     createPage({
       path: slug,
       component: PostTemplateComponent,
       context: {
         slug,
-        prev: index === 0 
-        ? null 
-        : {
-          slug: posts[index - 1].node.fields.slug,
-        },
-        next: index === posts.length - 1 
-        ? null 
-        : {
-          slug: posts[index + 1].node.fields.slug,
-        }
+        prev: next.fields.slug,
+        next: previous.fields.slug
       }
     })
   })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,21 +74,46 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     'src/templates/post_template.tsx',
   );
 
-  // Page Generating Function
-  const generatePostPage = ({
-    node: {
-      fields: { slug },
+  const posts = queryAllMarkdownData.data.allMarkdownRemark.edges
+  posts.forEach((
+    {
+      node: {
+        fields: { slug },
+      },
     },
-  }) => {
-    const pageOptions = {
+    index,
+  ) => {
+    createPage({
       path: slug,
       component: PostTemplateComponent,
-      context: { slug },
-    };
+      context: {
+        slug,
+        prev: index === 0 
+        ? null 
+        : {
+          slug: posts[index - 1].node.fields.slug,
+        },
+        next: index === posts.length - 1 
+        ? null 
+        : {
+          slug: posts[index + 1].node.fields.slug,
+        }
+      }
+    })
+  })
 
-    createPage(pageOptions);
-  };
+  // // Page Generating Function
+  // const generatePostPage = ({
+  //   node: {
+  //     fields: { slug },
+  //   },
+  // }) => {
+  //   const pageOptions = {
+  //     path: slug,
+  //     component: PostTemplateComponent,
+  //     context: { slug },
+  //   };
 
-  // Generate Post Page And Passing Slug Props for Query
-  queryAllMarkdownData.data.allMarkdownRemark.edges.forEach(generatePostPage);
+  //   createPage(pageOptions);
+  // };
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,16 +56,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
                 slug
               }
             }
-            next {
-              fields {
-                slug
-              }
-            }
-            previous {
-              fields {
-                slug
-              }
-            }
           }
         }
       }
@@ -89,16 +79,19 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     {
       node: {
         fields: { slug },
-      },
+      }
     },
+    index
   ) => {
+    const prev = index === 0 ? null : posts[index-1]
+    const next = index === posts.length -1 ? null: posts[index+1]
     createPage({
       path: slug,
       component: PostTemplateComponent,
       context: {
         slug,
-        prev: next.fields.slug,
-        next: previous.fields.slug
+        prev,
+        next,
       }
     })
   })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,19 +95,4 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       }
     })
   })
-
-  // // Page Generating Function
-  // const generatePostPage = ({
-  //   node: {
-  //     fields: { slug },
-  //   },
-  // }) => {
-  //   const pageOptions = {
-  //     path: slug,
-  //     component: PostTemplateComponent,
-  //     context: { slug },
-  //   };
-
-  //   createPage(pageOptions);
-  // };
 };

--- a/src/assets/left-icon.svg
+++ b/src/assets/left-icon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="30px" height="30px" viewBox="0 0 24 24" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.7071 4.29289C16.0976 4.68342 16.0976 5.31658 15.7071 5.70711L9.41421 12L15.7071 18.2929C16.0976 18.6834 16.0976 19.3166 15.7071 19.7071C15.3166 20.0976 14.6834 20.0976 14.2929 19.7071L7.29289 12.7071C7.10536 12.5196 7 12.2652 7 12C7 11.7348 7.10536 11.4804 7.29289 11.2929L14.2929 4.29289C14.6834 3.90237 15.3166 3.90237 15.7071 4.29289Z" fill="#000000"/>
+</svg>

--- a/src/assets/right-icon.svg
+++ b/src/assets/right-icon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="30px" height="30px" viewBox="0 0 24 24" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.29289 4.29289C8.68342 3.90237 9.31658 3.90237 9.70711 4.29289L16.7071 11.2929C17.0976 11.6834 17.0976 12.3166 16.7071 12.7071L9.70711 19.7071C9.31658 20.0976 8.68342 20.0976 8.29289 19.7071C7.90237 19.3166 7.90237 18.6834 8.29289 18.2929L14.5858 12L8.29289 5.70711C7.90237 5.31658 7.90237 4.68342 8.29289 4.29289Z" fill="#000000"/>
+</svg>

--- a/src/components/Post/PostContent.tsx
+++ b/src/components/Post/PostContent.tsx
@@ -86,13 +86,14 @@ const MarkdownRenderer = styled.div`
   ,
   a:hover {
     color: #f6546a;
+    text-decoration: underline;
   }
 
   // Adjust Code Style
   pre[class*='language-'] {
     margin: 30px 0;
     padding: 15px;
-    font-size: 15px;
+    font-size: 13px;
 
     ::-webkit-scrollbar-thumb {
       background: rgba(255, 255, 255, 0.5);

--- a/src/components/Post/PostPrevNextBtn.tsx
+++ b/src/components/Post/PostPrevNextBtn.tsx
@@ -43,8 +43,8 @@ const StyledPager = styled.nav`
   }
 `
 export type PrevNextProps = {
-  previousPagePath: string
-  nextPagePath: string
+  previousPagePath: string | null
+  nextPagePath: string | null
 }
 
 const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
@@ -56,24 +56,24 @@ const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
       <ul>
         <li>
           {previousPagePath !== null ? (
-            <Link to={previousPagePath.slug}>
-              <Left /> 이전글
+            <Link to={previousPagePath}>
+              <Left /> 다음글
             </Link>
           ) : (
             <span>
-              <Left /> 이전글
+              <Left /> 다음글
             </span>
           )}
         </li>
 
         <li>
           {nextPagePath !== null ? (
-            <Link to={nextPagePath.slug}>
-              다음글 <Right />
+            <Link to={nextPagePath}>
+              이전글 <Right />
             </Link>
           ) : (
             <span>
-              다음글 <Right />
+              이전글 <Right />
             </span>
           )}
         </li>

--- a/src/components/Post/PostPrevNextBtn.tsx
+++ b/src/components/Post/PostPrevNextBtn.tsx
@@ -43,8 +43,8 @@ const StyledPager = styled.nav`
   }
 `
 export type PrevNextProps = {
-  previousPagePath: string | null
-  nextPagePath: string | null
+  previousPagePath: string
+  nextPagePath: string
 }
 
 const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
@@ -55,8 +55,8 @@ const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
     <StyledPager>
       <ul>
         <li>
-          {previousPagePath ? (
-            <Link to={previousPagePath}>
+          {previousPagePath !== null ? (
+            <Link to={previousPagePath.slug}>
               <Left /> 이전글
             </Link>
           ) : (
@@ -67,8 +67,8 @@ const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
         </li>
 
         <li>
-          {nextPagePath ? (
-            <Link to={nextPagePath}>
+          {nextPagePath !== null ? (
+            <Link to={nextPagePath.slug}>
               다음글 <Right />
             </Link>
           ) : (

--- a/src/components/Post/PostPrevNextBtn.tsx
+++ b/src/components/Post/PostPrevNextBtn.tsx
@@ -1,0 +1,85 @@
+import React, { FunctionComponent } from 'react'
+import Left from '../../assets/left-icon.svg'
+import Right from '../../assets/right-icon.svg'
+import styled from '@emotion/styled'
+import { Link } from 'gatsby-link'
+
+const StyledPager = styled.nav`
+  height: 56px;
+  margin-bottom: 30px;
+
+  ul {
+    text-align: center;
+  }
+
+  li {
+    display: inline-block;
+    *display: block;
+    *zoom: 1;
+    height: 56px;
+    line-height: 56px;
+    white-space: nowrap;
+    margin: 0 10px;
+  }
+  svg {
+    margin-top: -3px;
+    width: 21px;
+    height: 21px;
+    vertical-align: middle;
+  }
+
+  a {
+    color: #333;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  span {
+    cursor: not-allowed;
+    color: #888;
+  }
+`
+export type PrevNextProps = {
+  previousPagePath: string | null
+  nextPagePath: string | null
+}
+
+const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({
+  previousPagePath,
+  nextPagePath,
+}) {
+  return (
+    <StyledPager>
+      <ul>
+        <li>
+          {previousPagePath ? (
+            <Link to={previousPagePath}>
+              <Left /> 이전글
+            </Link>
+          ) : (
+            <span>
+              <Left /> 이전글
+            </span>
+          )}
+        </li>
+
+        <li>
+          {nextPagePath ? (
+            <Link to={nextPagePath}>
+              다음글 <Right />
+            </Link>
+          ) : (
+            <span>
+              다음글 <Right />
+            </span>
+          )}
+        </li>
+      </ul>
+    </StyledPager>
+  )
+}
+
+export default PostPrevNextBtn

--- a/src/components/Post/PostPrevNextBtn.tsx
+++ b/src/components/Post/PostPrevNextBtn.tsx
@@ -43,8 +43,8 @@ const StyledPager = styled.nav`
   }
 `
 export type PrevNextProps = {
-  previousPagePath: string | null
-  nextPagePath: string | null
+  previousPagePath: string
+  nextPagePath: string
 }
 
 const PostPrevNextBtn: FunctionComponent<PrevNextProps> = function ({

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -7,6 +7,7 @@ import PostContent from 'components/Post/PostContent'
 import CommentWidget from 'components/Post/CommentWidget'
 import ScrollToTop from 'components/Common/ScrollToTop'
 import HeaderTheme from 'components/Common/HeaderTheme'
+import PostPrevNextBtn from 'components/Post/PostPrevNextBtn'
 
 type PostTemplateProps = {
   data: {
@@ -17,6 +18,10 @@ type PostTemplateProps = {
   location: {
     href: string
   }
+  pageContext: {
+    prev: string
+    next: string
+  }
 }
 
 const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
@@ -24,6 +29,7 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
     allMarkdownRemark: { edges },
   },
   location: { href },
+  pageContext: { prev, next },
 }) {
   const {
     node: {
@@ -51,6 +57,7 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
       />
       <HeaderTheme />
       <PostContent html={html} />
+      <PostPrevNextBtn previousPagePath={prev} nextPagePath={next} />
       <CommentWidget />
       <ScrollToTop />
     </Template>

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -29,8 +29,9 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
     allMarkdownRemark: { edges },
   },
   location: { href },
-  pageContext: { prev, next },
+  pageContext,
 }) {
+  // console.log(pageContext.next)
   const {
     node: {
       html,
@@ -57,7 +58,10 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
       />
       <HeaderTheme />
       <PostContent html={html} />
-      <PostPrevNextBtn previousPagePath={prev} nextPagePath={next} />
+      <PostPrevNextBtn
+        previousPagePath={pageContext.prev}
+        nextPagePath={pageContext.next}
+      />
       <CommentWidget />
       <ScrollToTop />
     </Template>

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -19,8 +19,20 @@ type PostTemplateProps = {
     href: string
   }
   pageContext: {
-    prev: string
-    next: string
+    prev: {
+      node: {
+        fields: {
+          slug: string
+        }
+      }
+    }
+    next: {
+      node: {
+        fields: {
+          slug: string
+        }
+      }
+    }
   }
 }
 
@@ -29,9 +41,8 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
     allMarkdownRemark: { edges },
   },
   location: { href },
-  pageContext,
+  pageContext: { prev, next },
 }) {
-  // console.log(pageContext.next)
   const {
     node: {
       html,
@@ -59,8 +70,8 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
       <HeaderTheme />
       <PostContent html={html} />
       <PostPrevNextBtn
-        previousPagePath={pageContext.prev}
-        nextPagePath={pageContext.next}
+        previousPagePath={prev ? prev.node.fields.slug : null}
+        nextPagePath={next ? next.node.fields.slug : null}
       />
       <CommentWidget />
       <ScrollToTop />


### PR DESCRIPTION
## Backgrounds
포스팅을 다 읽고 나서 이전글,다음글 컴포넌트를 추가하여 사용자가 다른 포스팅도 볼 수 있도록 유도합니다. 

## Changes 
- `gatsby-node.js` 에서 edges 배열을 순회하면서, 맨처음과 맨끝에 도달한 포스팅에 대해서는 slug값이 없도록 null로 설정했습니다. 
- `post_template.tsx`내 매개변수로 pageContext에서 `prev`와 `next`를 객체로 받아, node의 값이 있다면 이전과 다음 slug를 요청하고, 그렇지 않다면 null로 요청합니다. 
- `PostPrevNextBtn` : 이전글/다음글 컴포넌트 (props로 string 타입의 slug를 받습니다.) 