### PR TITLE
feat: Sync Dark mode in Utterance Tool

### DIFF
--- a/src/components/Post/CommentWidget.tsx
+++ b/src/components/Post/CommentWidget.tsx
@@ -1,5 +1,6 @@
 import React, { createRef, FunctionComponent, useEffect } from 'react'
 import styled from '@emotion/styled'
+import { isBrowser } from '../../util'
 
 const src = 'https://utteranc.es/client.js'
 const repo = 'dobyming/dobyming.github.io' // 자신 계정의 레포지토리로 설정
@@ -22,6 +23,10 @@ const UtterancesWrapper = styled.div`
 
 const CommentWidget: FunctionComponent = function () {
   const element = createRef<HTMLDivElement>()
+  if (!isBrowser) return null
+  const theme = document.body.classList.contains('dark')
+    ? 'photon-dark'
+    : 'github-light'
 
   useEffect(() => {
     if (element.current === null) return
@@ -33,7 +38,7 @@ const CommentWidget: FunctionComponent = function () {
       repo,
       'issue-term': 'pathname',
       label: 'Comment',
-      theme: `github-light`,
+      theme: theme,
       crossorigin: 'anonymous',
       async: 'true',
     }
@@ -44,6 +49,29 @@ const CommentWidget: FunctionComponent = function () {
 
     element.current.appendChild(utterances)
   }, [])
+
+  useEffect(() => {
+    const mutationObserver: MutationObserver = new MutationObserver(
+      mutationsList => {
+        mutationsList.forEach(mutation => {
+          if (mutation.attributeName === 'class') {
+            if (document.querySelector('.utterances-frame')) {
+              const theme = mutation.target.classList.contains('dark')
+                ? 'photon-dark'
+                : 'github-light'
+              const message = {
+                type: 'set-theme',
+                theme: theme,
+              }
+              const iframe = document.querySelector('.utterances-frame')
+              iframe.contentWindow.postMessage(message, 'https://utteranc.es')
+            }
+          }
+        })
+      },
+    )
+    mutationObserver.observe(document.body, { attributes: true })
+  }, [theme])
 
   return <UtterancesWrapper ref={element} />
 }


### PR DESCRIPTION
## Backgrounds
Utterance는 Script로 생성되기 때문에, 다크 모드 적용 시 Theme에 맞춰 바뀌기 위해선 customize를 해야되는 부분이 필요했습니다. 

## Changes
해당 프로젝트에서 다크모드의 전환 유무의 포인트는 **body의 className**입니다. light냐 dark냐에 따라서 DOM 트리가 구축될때, body의 className에 따라 유동적으로 변화할 수 있는 idea가 필요했습니다. 구글링 결과, `MutationObserver` 라는 Constructor가 이 개념을 활용할 수 있다고 판단했습니다.

Utterance theme을 바꾸기 위해서, body의 className을 참조하여 다크 <-> 라이트 모드를 전환될때마다 body의 className의 변화를 감지하기 위해 `MutationObserver` 생성자를 활용했습니다. 

감지된 body의 className에 따라 삼항연산자로 theme을 할당 후, iframe에 `postMessage()`로 전달합니다. 그리고 `attributes`의 상태값을 true로 지정하여, body의 class의 변화를 감지할 수 있도록 수행합니다. 