### PR TITLE
fix: React Hydration error

### DIFF
--- a/src/components/Common/ClientOnly.tsx
+++ b/src/components/Common/ClientOnly.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect, ReactNode, FunctionComponent } from 'react'
+
+type ClientProps = {
+  children: ReactNode
+}
+
+const ClientOnly: FunctionComponent<ClientProps> = function ({ children }) {
+  const [isMounted, setIsMounted] = useState<boolean>(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!isMounted) {
+    return null
+  }
+
+  return children
+}
+
+export default ClientOnly

--- a/src/components/Common/HeaderTheme.tsx
+++ b/src/components/Common/HeaderTheme.tsx
@@ -3,6 +3,8 @@ import Sun from '../../assets/sun.svg'
 import Moon from '../../assets/moon.svg'
 import '../../styles/theme.css'
 import styled from '@emotion/styled'
+import { isBrowser } from '../../util'
+import ClientOnly from './ClientOnly'
 
 const ThemeHeader = styled.div`
   position: absolute;
@@ -13,7 +15,7 @@ const ThemeHeader = styled.div`
 
 const HeaderTheme = () => {
   const [isDark, setIsDark] = useState<boolean>(false)
-  if (typeof window === 'undefined') return null
+  if (!isBrowser()) return null
   const userTheme = window.localStorage.getItem('color-theme')
 
   // Belong to isDark state, store theme in localStorage
@@ -47,13 +49,15 @@ const HeaderTheme = () => {
   }, [])
 
   return (
-    <ThemeHeader onClick={handleTheme}>
-      {isDark ? (
-        <Sun stroke="#FF5733" fill="#FF5733" />
-      ) : (
-        <Moon fill="#FFD700" stroke="#FFD700" />
-      )}
-    </ThemeHeader>
+    <ClientOnly>
+      <ThemeHeader onClick={handleTheme}>
+        {isDark ? (
+          <Sun stroke="#FF5733" fill="#FF5733" />
+        ) : (
+          <Moon fill="#FFD700" stroke="#FFD700" />
+        )}
+      </ThemeHeader>
+    </ClientOnly>
   )
 }
 

--- a/src/components/Post/CommentWidget.tsx
+++ b/src/components/Post/CommentWidget.tsx
@@ -65,7 +65,7 @@ const CommentWidget: FunctionComponent = function () {
                 }
                 const iframe =
                   window.document.querySelector('.utterances-frame')
-                iframe.contentWindow.postMessage(message, 'https://utteranc.es')
+                iframe.contentWindow.postMessage(message, src)
               }
             }
           })


### PR DESCRIPTION
## Backgrounds
#418 #423 `Minified Error` 라는 에러가 콘솔에 감지됌.
 
원인 파악 결과, **React Hydration** 에러로 Gatsby에서 Pre-Render되는 HTML 파일과 Pre-Render 된 후, React의 hydration이 이루어질 때, React에서 Virtual Dom으로 쌓아올린 HTML 파일과 Gatsby에서 Pre-Render된 HTML 파일과 서로 일치하지 않게 되어 자체적으로 React에서 렌더링된 HTML 파일로 replace하게 되어 발생하는 에러 .

## Changes
`ClientOnly.tsx`을 `HeaderTheme`의 최상단 컴포넌트로 두어 `HeaderTheme`이 DOM에 담기지 않도록 Validate을 수행합니다. 