### PR TITLE
feat: add Helmet component in about page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,12 @@
 module.exports = {
   siteMetadata: {
-    title: `dobyming - TechBlog`,
+    title: `dobyming | TechBlog`,
     description: `주니어 프론트엔드 개발자로서 TIL을 남기는 공간입니다.`,
-    author: `dobyming`,
+    author: `Damin Kim`,
+    resume: {
+      title: 'About | Damin Kim',
+      description: 'Introducing Damin Kim.',
+    },
     siteUrl: 'https://dobyming.github.io/', // 배포 후 변경
   },
   plugins: [

--- a/src/components/Common/ResumeTemplate.tsx
+++ b/src/components/Common/ResumeTemplate.tsx
@@ -1,0 +1,40 @@
+import React, { FunctionComponent, ReactNode } from 'react'
+import { Helmet } from 'react-helmet'
+
+type ResumeProps = {
+  title: string
+  description: string
+  children: ReactNode
+}
+
+const ResumeTemplate: FunctionComponent<ResumeProps> = function ({
+  title,
+  description,
+  children,
+}) {
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+
+        <meta name="description" content={description} />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta httpEquiv="Content-Type" content="text/html;charset=UTF-8" />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:site_name" content={title} />
+
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+
+        <html lang="ko" />
+      </Helmet>
+      {children}
+    </>
+  )
+}
+
+export default ResumeTemplate

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,10 +1,19 @@
 import React, { FunctionComponent } from 'react'
 import { graphql } from 'gatsby'
 import { ResumeType } from 'types/PostItem.types'
+import ResumeTemplate from 'components/Common/ResumeTemplate'
 import styled from '@emotion/styled'
 
 type AboutProps = {
   data: {
+    site: {
+      siteMetadata: {
+        resume: {
+          title: string
+          description: string
+        }
+      }
+    }
     allMarkdownRemark: {
       edges: ResumeType
     }
@@ -125,17 +134,38 @@ const MarkdownRenderer = styled.div`
   }
 `
 
-const about: FunctionComponent<AboutProps> = function ({ data }) {
-  const resumes = data.allMarkdownRemark.edges
+const about: FunctionComponent<AboutProps> = function ({
+  data: {
+    site: {
+      siteMetadata: {
+        resume: { title, description },
+      },
+    },
+    allMarkdownRemark: { edges },
+  },
+}) {
+  const resumes = edges
   const resume = resumes.map(({ node }) => node)[0]
 
-  return <MarkdownRenderer dangerouslySetInnerHTML={{ __html: resume.html }} />
+  return (
+    <ResumeTemplate title={title} description={description}>
+      <MarkdownRenderer dangerouslySetInnerHTML={{ __html: resume.html }} />
+    </ResumeTemplate>
+  )
 }
 
 export default about
 
 export const queryResume = graphql`
   query {
+    site {
+      siteMetadata {
+        resume {
+          title
+          description
+        }
+      }
+    }
     allMarkdownRemark(filter: { frontmatter: { categories: { eq: null } } }) {
       edges {
         node {


### PR DESCRIPTION
## Backgrounds
https://github.com/dobyming/dobyming.github.io/issues/40#issue-1800401120

## Changes
- Add new Component for Resume Page `ResumeTemplate`. This Component handles only for Resume title tag, and description.

## Result Screen
![2023-07-13 10;14;43](https://github.com/dobyming/dobyming.github.io/assets/90133704/ab116f38-3c46-4ff3-9a85-35acd4ca6821)

