### PR TITLE
modify: refact NavBars components and add new SVG

### DIFF
--- a/src/assets/reorder.svg
+++ b/src/assets/reorder.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="35px" height="35px" viewBox="0 0 24 24" fill="current" stroke="current" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.75 10C19.75 10.4142 19.4142 10.75 19 10.75L5 10.75C4.58579 10.75 4.25 10.4142 4.25 10C4.25 9.58579 4.58579 9.25 5 9.25L19 9.25C19.4142 9.25 19.75 9.58579 19.75 10Z" fill="#1C274C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.75 14C19.75 14.4142 19.4142 14.75 19 14.75L5 14.75C4.58579 14.75 4.25 14.4142 4.25 14C4.25 13.5858 4.58579 13.25 5 13.25L19 13.25C19.4142 13.25 19.75 13.5858 19.75 14Z" fill="#1C274C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.75 6C19.75 6.41421 19.4142 6.75 19 6.75L5 6.75C4.58579 6.75 4.25 6.41421 4.25 6C4.25 5.58579 4.58579 5.25 5 5.25L19 5.25C19.4142 5.25 19.75 5.58579 19.75 6Z" fill="#1C274C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.75 18C19.75 18.4142 19.4142 18.75 19 18.75L5 18.75C4.58579 18.75 4.25 18.4142 4.25 18C4.25 17.5858 4.58579 17.25 5 17.25L19 17.25C19.4142 17.25 19.75 17.5858 19.75 18Z" fill="#1C274C"/>
+</svg>

--- a/src/components/Common/HeaderTheme.tsx
+++ b/src/components/Common/HeaderTheme.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useLayoutEffect, useCallback } from 'react'
+import React from 'react'
+import useTheme from 'hooks/useTheme'
 import Sun from '../../assets/sun.svg'
 import Moon from '../../assets/moon.svg'
 import '../../styles/theme.css'
 import styled from '@emotion/styled'
-import { isBrowser } from '../../util'
 import ClientOnly from './ClientOnly'
 
 const ThemeHeader = styled.button`
@@ -16,43 +16,11 @@ const ThemeHeader = styled.button`
 `
 
 const HeaderTheme = () => {
-  const [isDark, setIsDark] = useState<boolean>(false)
-  if (!isBrowser()) return null
-  const userTheme = window.localStorage.getItem('color-theme')
-
-  // Belong to isDark state, store theme in localStorage
-  const saveTheme = (it: boolean) => {
-    if (it) {
-      window.localStorage.setItem('color-theme', 'dark')
-    } else {
-      window.localStorage.setItem('color-theme', 'light')
-    }
-  }
-
-  // trigger theme change refer localStorage's key-value
-  useLayoutEffect(() => {
-    if (userTheme === 'dark') {
-      document.body.classList.remove('light')
-      document.body.classList.add('dark')
-      setIsDark(true)
-    } else {
-      document.body.classList.remove('dark')
-      document.body.classList.add('light')
-      setIsDark(false)
-    }
-  }, [userTheme])
-
-  // while clicking button, what to show svg logo
-  const handleTheme = useCallback(() => {
-    setIsDark(prev => {
-      saveTheme(!prev)
-      return !prev
-    })
-  }, [])
+  const [isDark, setIsDark] = useTheme()
 
   return (
     <ClientOnly>
-      <ThemeHeader className="themeIcon" onClick={handleTheme}>
+      <ThemeHeader className="themeIcon" onClick={setIsDark}>
         {isDark ? (
           <Sun stroke="#FF5733" fill="#FF5733" />
         ) : (

--- a/src/components/Common/Navigation/BottomNav.tsx
+++ b/src/components/Common/Navigation/BottomNav.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import GithubIcon from '../../../assets/github.svg'
+import RSS from '../../../assets/rss.svg'
+import { Link } from 'gatsby'
+
+const BottomWrapper = styled.div`
+  display: flex;
+  padding-top: 5px;
+  justify-content: center;
+
+  .rssFeed {
+    margin: 5px;
+  }
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`
+
+function BottomNav() {
+  return (
+    <BottomWrapper>
+      <a
+        href="https://github.com/dobyming"
+        aria-label="GitHub"
+        target={'_blank'}
+      >
+        <GithubIcon className="githubIcon" />
+      </a>
+      <Link to="/rss.xml" className="rssFeed" aria-label="RSS">
+        <RSS fill="black" />
+      </Link>
+    </BottomWrapper>
+  )
+}
+
+export default BottomNav

--- a/src/components/Common/Navigation/NavBar.tsx
+++ b/src/components/Common/Navigation/NavBar.tsx
@@ -34,7 +34,7 @@ const NavBarContainer = styled.div`
   }
 `
 
-function NavBar() {
+const NavBar = () => {
   return (
     <NavBarContainer>
       <HeaderTheme />

--- a/src/components/Common/Navigation/NavBar.tsx
+++ b/src/components/Common/Navigation/NavBar.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import styled from '@emotion/styled'
+import HeaderTheme from '../HeaderTheme'
+import SearchIcon from '../../../assets/search.svg'
+
+const NavBarContainer = styled.div`
+  flex: 30%;
+  display: flex;
+  align-items: center;
+  padding-right: 5%;
+
+  .searchIcon {
+    position: absolute;
+    top: 1.3rem;
+    right: 5rem;
+    cursor: pointer;
+  }
+
+  .about {
+    position: absolute;
+    top: 1.5rem;
+    right: 8.3rem;
+    font-size: 17px;
+    cursor: pointer;
+
+    &:hover {
+      color: gray;
+    }
+  }
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`
+
+function NavBar() {
+  return (
+    <NavBarContainer>
+      <HeaderTheme />
+      <Link to="/Search" aria-label="Search">
+        <SearchIcon fill="black" className="searchIcon" />
+      </Link>
+      <Link to="/about" aria-label="About">
+        <p className="about">About</p>
+      </Link>
+    </NavBarContainer>
+  )
+}
+
+export default NavBar

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
-import HeaderTheme from 'components/Common/HeaderTheme'
-import GithubIcon from '../../assets/github.svg'
-import RSS from '../../assets/rss.svg'
 import { Link } from 'gatsby'
 import { isBrowser } from '../../util'
-import SearchIcon from '../../assets/search.svg'
+import BottomNav from './../Common/Navigation/BottomNav'
+import NavBar from 'components/Common/Navigation/NavBar'
 
 const Background = styled.div`
   position: fixed;
@@ -47,25 +45,6 @@ const Wrapper = styled.div`
   height: 100px;
   margin: 0 auto;
 
-  .searchIcon {
-    position: absolute;
-    top: 1.5rem;
-    right: 5rem;
-    cursor: pointer;
-  }
-
-  .about {
-    position: absolute;
-    top: 1.5rem;
-    right: 8.3rem;
-    font-size: 17px;
-    cursor: pointer;
-
-    &:hover {
-      color: gray;
-    }
-  }
-
   @media (max-width: 768px) {
     width: 100%;
     height: 80px;
@@ -104,16 +83,6 @@ const Title = styled(Link)`
   }
 `
 
-const SvgNav = styled.div`
-  display: flex;
-  padding-top: 5px;
-  justify-content: center;
-
-  .rssFeed {
-    margin: 5px;
-  }
-`
-
 const Introduction = () => {
   const [scrolled, setScrolled] = useState<boolean>(false)
   // when to trigger event
@@ -131,27 +100,9 @@ const Introduction = () => {
   return (
     <Background className={scrolled ? 'scroll' : ''}>
       <Wrapper>
-        <HeaderTheme />
-        <Link to="/Search" aria-label="Search">
-          <SearchIcon fill="black" className="searchIcon" />
-        </Link>
-        <Link to="/about" aria-label="About">
-          <p className="about">About</p>
-        </Link>
-
+        <NavBar />
         <Title to={'/'}>dobyming</Title>
-        <SvgNav>
-          <a
-            href="https://github.com/dobyming"
-            aria-label="GitHub"
-            target={'_blank'}
-          >
-            <GithubIcon className="githubIcon" />
-          </a>
-          <Link to="/rss.xml" className="rssFeed" aria-label="RSS">
-            <RSS fill="black" />
-          </Link>
-        </SvgNav>
+        <BottomNav />
       </Wrapper>
       <hr />
     </Background>

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -1,16 +1,22 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import styled from '@emotion/styled'
 import { Link } from 'gatsby'
 import { isBrowser } from '../../util'
 import BottomNav from './../Common/Navigation/BottomNav'
 import NavBar from 'components/Common/Navigation/NavBar'
+import ReorderIcon from '../../assets/reorder.svg'
+import CloseIcon from '../../assets/close.svg'
+
+type NavBarExtendendProps = {
+  extendNavBar: boolean
+}
 
 const Background = styled.div`
   position: fixed;
   width: 100%;
   top: 0;
   left: 0;
-  z-index: 3;
+  z-index: 1;
 
   hr {
     width: 768px;
@@ -83,11 +89,56 @@ const Title = styled(Link)`
   }
 `
 
-const Introduction = () => {
-  const [scrolled, setScrolled] = useState<boolean>(false)
-  // when to trigger event
-  const onScroll = () => setScrolled(window.scrollY > 20)
+const OpenLinksButton = styled.button`
+  position: absolute;
+  top: 1.3rem;
+  right: 1rem;
 
+  width: 35px;
+  height: 35px;
+  background: none;
+  border: none;
+  cursor: pointer;
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+`
+
+/* Spread Links in Tab(Reorder) button */
+const NavbarExtendedContainer = styled.div<NavBarExtendendProps>`
+  width: 100%;
+  height: ${props => (props.extendNavBar ? '20vh' : '')};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  a {
+    color: ${isBrowser() && window.document.body.classList.contains('dark')};
+    font-size: 20px;
+    text-decoration: none;
+    margin: 10px;
+  }
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+`
+
+/* Each Link component in Extended Container */
+const NavbarLinkExtended = styled(Link)`
+  color: ${isBrowser() && window.document.body.classList.contains('dark')};
+  font-size: 20px;
+  text-decoration: none;
+  margin: 10px;
+`
+
+const Introduction = () => {
+  const [extendNavbar, setExtendNavbar] = useState(false)
+  const [scrolled, setScrolled] = useState<boolean>(false)
+
+  /* when to trigger scroll event */
+  const onScroll = () => setScrolled(window.scrollY > 20)
   useEffect(() => {
     if (!isBrowser) {
       return
@@ -99,11 +150,29 @@ const Introduction = () => {
 
   return (
     <Background className={scrolled ? 'scroll' : ''}>
+      <NavBar />
+      <OpenLinksButton onClick={() => setExtendNavbar(cur => !cur)}>
+        {extendNavbar ? (
+          <CloseIcon className="closeIcon" stroke="#000000" />
+        ) : (
+          <ReorderIcon className="reOrder" />
+        )}
+      </OpenLinksButton>
+
       <Wrapper>
-        <NavBar />
         <Title to={'/'}>dobyming</Title>
         <BottomNav />
       </Wrapper>
+      {extendNavbar && (
+        <NavbarExtendedContainer
+          className="navBarExtended"
+          extendNavBar={extendNavbar}
+        >
+          <NavbarLinkExtended to="/about">About</NavbarLinkExtended>
+          <NavbarLinkExtended to="/Search">Search</NavbarLinkExtended>
+          <a href="https://github.com/dobyming">Github</a>
+        </NavbarExtendedContainer>
+      )}
       <hr />
     </Background>
   )

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { Link } from 'gatsby'
 import { isBrowser } from '../../util'
+import useTheme from 'hooks/useTheme'
 import BottomNav from './../Common/Navigation/BottomNav'
 import NavBar from 'components/Common/Navigation/NavBar'
 import ReorderIcon from '../../assets/reorder.svg'
@@ -89,7 +90,7 @@ const Title = styled(Link)`
   }
 `
 
-const OpenLinksButton = styled.button`
+const OpenReorderIcon = styled.button`
   position: absolute;
   top: 1.3rem;
   right: 1rem;
@@ -108,7 +109,7 @@ const OpenLinksButton = styled.button`
 /* Spread Links in Tab(Reorder) button */
 const NavbarExtendedContainer = styled.div<NavBarExtendendProps>`
   width: 100%;
-  height: ${props => (props.extendNavBar ? '20vh' : '')};
+  height: ${props => (props.extendNavBar ? '25vh' : '')};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -133,9 +134,17 @@ const NavbarLinkExtended = styled(Link)`
   margin: 10px;
 `
 
+const ThemeNavExtended = styled.button`
+  font-size: 20px;
+  margin: 10px;
+  border: none;
+  background-color: transparent;
+`
+
 const Introduction = () => {
   const [extendNavbar, setExtendNavbar] = useState(false)
   const [scrolled, setScrolled] = useState<boolean>(false)
+  const [isDark, setIsDark] = useTheme()
 
   /* when to trigger scroll event */
   const onScroll = () => setScrolled(window.scrollY > 20)
@@ -151,18 +160,19 @@ const Introduction = () => {
   return (
     <Background className={scrolled ? 'scroll' : ''}>
       <NavBar />
-      <OpenLinksButton onClick={() => setExtendNavbar(cur => !cur)}>
+      <OpenReorderIcon onClick={() => setExtendNavbar(cur => !cur)}>
         {extendNavbar ? (
           <CloseIcon className="closeIcon" stroke="#000000" />
         ) : (
           <ReorderIcon className="reOrder" />
         )}
-      </OpenLinksButton>
+      </OpenReorderIcon>
 
       <Wrapper>
         <Title to={'/'}>dobyming</Title>
         <BottomNav />
       </Wrapper>
+
       {extendNavbar && (
         <NavbarExtendedContainer
           className="navBarExtended"
@@ -171,8 +181,12 @@ const Introduction = () => {
           <NavbarLinkExtended to="/about">About</NavbarLinkExtended>
           <NavbarLinkExtended to="/Search">Search</NavbarLinkExtended>
           <a href="https://github.com/dobyming">Github</a>
+          <ThemeNavExtended onClick={setIsDark}>
+            {isDark ? 'Light' : 'Dark'}
+          </ThemeNavExtended>
         </NavbarExtendedContainer>
       )}
+
       <hr />
     </Background>
   )

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,44 @@
+import { useState, useLayoutEffect, useCallback } from 'react'
+import { isBrowser } from '../util'
+
+const useTheme = () => {
+  const [theme, setTheme] = useState<boolean>(false)
+
+  const saveTheme = (it: boolean) => {
+    if (isBrowser()) {
+      if (it) {
+        window.localStorage.setItem('color-theme', 'dark')
+      } else {
+        window.localStorage.setItem('color-theme', 'light')
+      }
+    }
+  }
+
+  /* Trigger theme modification by refering localStorage */
+  if (isBrowser()) {
+    const userTheme = window.localStorage.getItem('color-theme')
+    useLayoutEffect(() => {
+      if (userTheme === 'dark') {
+        document.body.classList.remove('light')
+        document.body.classList.add('dark')
+        setTheme(true)
+      } else {
+        document.body.classList.remove('dark')
+        document.body.classList.add('light')
+        setTheme(false)
+      }
+    }, [userTheme])
+  }
+
+  /* Theme Change Button logic */
+  const handleTheme = useCallback(() => {
+    setTheme(prev => {
+      saveTheme(!prev)
+      return !prev
+    })
+  }, [])
+
+  return [theme, handleTheme] as const
+}
+
+export default useTheme

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -30,6 +30,7 @@ h3,
 h4,
 h5,
 hr,
+button,
 input,
 a,
 p,
@@ -65,10 +66,6 @@ a::before {
     fill: var(--color-text);
 }
 
-.ScrollToTop path {
-    fill: var(--color-text)
-}
-
 .rssFeed path {
     fill: var(--color-text)
 }
@@ -79,6 +76,11 @@ a::before {
 
 .closeIcon path {
     stroke: var(--color-text)
+}
+
+.reOrder path {
+    stroke: var(--color-text);
+    fill: var(--color-text);
 }
 
 /* div Tags Dark Mode Themeing */
@@ -94,4 +96,8 @@ div .postItemWrapper {
 div .scroll {
     background-color: var(--color-background);
     box-shadow: var(--color-Introduction-shadow);
+}
+
+div .navBarExtended {
+    background-color: var(--color-background);
 }


### PR DESCRIPTION
## Backgrounds
While each function in `Introduction` Component getting larger (headerToggleTheme, Search page, About page) I feel need for Implementing those components in unified Component. Also, when accessing with mobile-web platform(Responsive App), convert these three Components into one Component (to `Reorder` Icon.)

## Changes
- `BottomNav` : Github Icon & RSS Feed Icon 
- `NavBar` : About Page / Search Page / HeaderTheme(*Dark/Light Toggle Theme)

+) Also I'm gonna create new component `Reorder` , so when user access web page with mobile then `NavBar` Component will turn into one single Component `Reorder`. 