### PR TITLE
fix: 연관 검색어에 resume 안뜨게 조정

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -129,7 +129,7 @@ module.exports = {
         // 인덱스를 만들고자 하는 데이터의 쿼리
         query: `
           {
-            allMarkdownRemark {
+            allMarkdownRemark(filter: { frontmatter: { categories: { ne: null } } }) {
               nodes {
                 id
                 rawMarkdownBody


### PR DESCRIPTION
## Backgrounds
https://github.com/dobyming/dobyming.github.io/issues/43

![2023-07-24 17;24;32](https://github.com/dobyming/dobyming.github.io/assets/90133704/dee11359-515c-4391-8ccf-ac8ff701d60f)

## Changes
- Handle GraphQL query. if category is null then fuse.js will not create index for search. 