### PR TITLE
fix: Handle media query for navbar mobile UI

### DIFF
--- a/src/components/Common/Navigation/BottomNav.tsx
+++ b/src/components/Common/Navigation/BottomNav.tsx
@@ -13,7 +13,7 @@ const BottomWrapper = styled.div`
     margin: 5px;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 767.2px) {
     display: none;
   }
 `

--- a/src/components/Common/Navigation/NavBar.tsx
+++ b/src/components/Common/Navigation/NavBar.tsx
@@ -29,7 +29,7 @@ const NavBarContainer = styled.div`
     }
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 767.2px) {
     display: none;
   }
 `

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -109,8 +109,9 @@ const OpenReorderIcon = styled.button`
 /* Spread Links in Tab(Reorder) button */
 const NavbarExtendedContainer = styled.div<NavBarExtendendProps>`
   width: 100%;
-  height: ${props => (props.extendNavBar ? '25vh' : '')};
+  height: ${props => (props.extendNavBar ? '23vh' : '')};
   display: flex;
+  box-shadow: 0 5px 5px rgba(0, 0, 0, 0.3);
   flex-direction: column;
   align-items: center;
 
@@ -138,6 +139,7 @@ const ThemeNavExtended = styled.button`
   font-size: 20px;
   margin: 10px;
   border: none;
+  cursor: pointer;
   background-color: transparent;
 `
 


### PR DESCRIPTION
1. `ReorderIcon` 보여지는 기준
min-width: 768px: 768px이상일 경우 적용
그러면 767까진 보이다가 768px이 되면 안보여야 함 

2. `NavBar`와 `BottomNav`가 보여지는 기준
max-width: 767.2px: 767.2px 이하일 경우 적용
그러면 767.2px 까지는 안보이는 상태였다가 768px에서는 보임