### PR TITLE
modfiy: change composite of reorder ui(extend navbar)

### DIFF
--- a/src/components/Common/Navigation/ExtendNavBar.tsx
+++ b/src/components/Common/Navigation/ExtendNavBar.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent } from 'react'
+import styled from '@emotion/styled'
+import { Link } from 'gatsby'
+import { isBrowser } from './../../../util'
+import useTheme from 'hooks/useTheme'
+
+type NavBarExtendendProps = {
+  extendNavBar: boolean
+}
+
+const NavbarContainer = styled.div<NavBarExtendendProps>`
+  width: 100%;
+  height: ${props => (props.extendNavBar ? '100vh' : '')};
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+`
+
+const NavbarLinks = styled.div`
+  width: 100%;
+  height: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  a {
+    color: ${isBrowser() && window.document.body.classList.contains('dark')};
+    font-size: 20px;
+    text-decoration: none;
+    margin: 10px;
+  }
+`
+
+const NavLink = styled(Link)`
+  color: ${isBrowser() && window.document.body.classList.contains('dark')};
+  text-decoration: none;
+`
+
+const NavThemeLink = styled.button`
+  font-size: 20px;
+  margin: 10px;
+  border: none;
+  cursor: pointer;
+  background-color: transparent;
+`
+
+const ExtendNavBar: FunctionComponent<NavBarExtendendProps> = function ({
+  extendNavBar,
+}) {
+  const [isDark, setIsDark] = useTheme()
+  return (
+    <>
+      {extendNavBar && (
+        <NavbarContainer className="navBarExtended" extendNavBar={extendNavBar}>
+          <NavbarLinks>
+            <NavLink to="/about">About</NavLink>
+            <NavLink to="/Search">Search</NavLink>
+            <a href="https://github.com/dobyming">GitHub</a>
+            <NavThemeLink onClick={setIsDark}>
+              {isDark ? 'Light' : 'Dark'}
+            </NavThemeLink>
+          </NavbarLinks>
+        </NavbarContainer>
+      )}
+    </>
+  )
+}
+
+export default ExtendNavBar

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -2,15 +2,11 @@ import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { Link } from 'gatsby'
 import { isBrowser } from '../../util'
-import useTheme from 'hooks/useTheme'
 import BottomNav from './../Common/Navigation/BottomNav'
 import NavBar from 'components/Common/Navigation/NavBar'
 import ReorderIcon from '../../assets/reorder.svg'
 import CloseIcon from '../../assets/close.svg'
-
-type NavBarExtendendProps = {
-  extendNavBar: boolean
-}
+import ExtendNavBar from 'components/Common/Navigation/ExtendNavBar'
 
 const Background = styled.div`
   position: fixed;
@@ -106,52 +102,11 @@ const OpenReorderIcon = styled.button`
   }
 `
 
-/* Spread Links in Tab(Reorder) button */
-const NavbarContainer = styled.div<NavBarExtendendProps>`
-  width: 100%;
-  height: ${props => (props.extendNavBar ? '100vh' : '')};
-
-  @media (min-width: 768px) {
-    display: none;
-  }
-`
-
-const NavbarLinks = styled.div`
-  width: 100%;
-  height: 80%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  a {
-    color: ${isBrowser() && window.document.body.classList.contains('dark')};
-    font-size: 20px;
-    text-decoration: none;
-    margin: 10px;
-  }
-`
-
-/* Each Link component in Extended Container */
-const NavLink = styled(Link)`
-  color: ${isBrowser() && window.document.body.classList.contains('dark')};
-  text-decoration: none;
-`
-
-const NavThemeLink = styled.button`
-  font-size: 20px;
-  margin: 10px;
-  border: none;
-  cursor: pointer;
-  background-color: transparent;
-`
-
 const Introduction = () => {
-  const [extendNavbar, setExtendNavbar] = useState(false)
+  const [extendNavBar, setExtendNavBar] = useState(false)
   const [scrolled, setScrolled] = useState<boolean>(false)
-  const [isDark, setIsDark] = useTheme()
 
-  /* when to trigger scroll event */
+  /** when to trigger scroll event */
   const onScroll = () => setScrolled(window.scrollY > 20)
   useEffect(() => {
     if (!isBrowser) {
@@ -165,8 +120,8 @@ const Introduction = () => {
   return (
     <Background className={scrolled ? 'scroll' : ''}>
       <NavBar />
-      <OpenReorderIcon onClick={() => setExtendNavbar(cur => !cur)}>
-        {extendNavbar ? (
+      <OpenReorderIcon onClick={() => setExtendNavBar(cur => !cur)}>
+        {extendNavBar ? (
           <CloseIcon className="closeIcon" stroke="#000000" />
         ) : (
           <ReorderIcon className="reOrder" />
@@ -176,18 +131,7 @@ const Introduction = () => {
         <Title to={'/'}>dobyming</Title>
         <BottomNav />
       </Wrapper>
-      {extendNavbar && (
-        <NavbarContainer className="navBarExtended" extendNavBar={extendNavbar}>
-          <NavbarLinks>
-            <NavLink to="/about">About</NavLink>
-            <NavLink to="/Search">Search</NavLink>
-            <a href="https://github.com/dobyming">GitHub</a>
-            <NavThemeLink onClick={setIsDark}>
-              {isDark ? 'Light' : 'Dark'}
-            </NavThemeLink>
-          </NavbarLinks>
-        </NavbarContainer>
-      )}
+      {extendNavBar && <ExtendNavBar extendNavBar={extendNavBar} />}
       <hr />
     </Background>
   )

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -107,12 +107,21 @@ const OpenReorderIcon = styled.button`
 `
 
 /* Spread Links in Tab(Reorder) button */
-const NavbarExtendedContainer = styled.div<NavBarExtendendProps>`
+const NavbarContainer = styled.div<NavBarExtendendProps>`
   width: 100%;
-  height: ${props => (props.extendNavBar ? '23vh' : '')};
+  height: ${props => (props.extendNavBar ? '100vh' : '')};
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+`
+
+const NavbarLinks = styled.div`
+  width: 100%;
+  height: 80%;
   display: flex;
-  box-shadow: 0 5px 5px rgba(0, 0, 0, 0.3);
   flex-direction: column;
+  justify-content: center;
   align-items: center;
 
   a {
@@ -121,21 +130,15 @@ const NavbarExtendedContainer = styled.div<NavBarExtendendProps>`
     text-decoration: none;
     margin: 10px;
   }
-
-  @media (min-width: 768px) {
-    display: none;
-  }
 `
 
 /* Each Link component in Extended Container */
-const NavbarLinkExtended = styled(Link)`
+const NavLink = styled(Link)`
   color: ${isBrowser() && window.document.body.classList.contains('dark')};
-  font-size: 20px;
   text-decoration: none;
-  margin: 10px;
 `
 
-const ThemeNavExtended = styled.button`
+const NavThemeLink = styled.button`
   font-size: 20px;
   margin: 10px;
   border: none;
@@ -169,26 +172,22 @@ const Introduction = () => {
           <ReorderIcon className="reOrder" />
         )}
       </OpenReorderIcon>
-
       <Wrapper>
         <Title to={'/'}>dobyming</Title>
         <BottomNav />
       </Wrapper>
-
       {extendNavbar && (
-        <NavbarExtendedContainer
-          className="navBarExtended"
-          extendNavBar={extendNavbar}
-        >
-          <NavbarLinkExtended to="/about">About</NavbarLinkExtended>
-          <NavbarLinkExtended to="/Search">Search</NavbarLinkExtended>
-          <a href="https://github.com/dobyming">Github</a>
-          <ThemeNavExtended onClick={setIsDark}>
-            {isDark ? 'Light' : 'Dark'}
-          </ThemeNavExtended>
-        </NavbarExtendedContainer>
+        <NavbarContainer className="navBarExtended" extendNavBar={extendNavbar}>
+          <NavbarLinks>
+            <NavLink to="/about">About</NavLink>
+            <NavLink to="/Search">Search</NavLink>
+            <a href="https://github.com/dobyming">GitHub</a>
+            <NavThemeLink onClick={setIsDark}>
+              {isDark ? 'Light' : 'Dark'}
+            </NavThemeLink>
+          </NavbarLinks>
+        </NavbarContainer>
       )}
-
       <hr />
     </Background>
   )

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -103,7 +103,7 @@ const OpenReorderIcon = styled.button`
 `
 
 const Introduction = () => {
-  const [extendNavBar, setExtendNavBar] = useState(false)
+  const [isExtendNavBar, setExtendNavBar] = useState(false)
   const [scrolled, setScrolled] = useState<boolean>(false)
 
   /** when to trigger scroll event */
@@ -121,7 +121,7 @@ const Introduction = () => {
     <Background className={scrolled ? 'scroll' : ''}>
       <NavBar />
       <OpenReorderIcon onClick={() => setExtendNavBar(cur => !cur)}>
-        {extendNavBar ? (
+        {isExtendNavBar ? (
           <CloseIcon className="closeIcon" stroke="#000000" />
         ) : (
           <ReorderIcon className="reOrder" />
@@ -131,7 +131,7 @@ const Introduction = () => {
         <Title to={'/'}>dobyming</Title>
         <BottomNav />
       </Wrapper>
-      {extendNavBar && <ExtendNavBar extendNavBar={extendNavBar} />}
+      {isExtendNavBar && <ExtendNavBar extendNavBar={isExtendNavBar} />}
       <hr />
     </Background>
   )


### PR DESCRIPTION
## Backgrounds 
핸드폰 기종 별로 navbar를 extend 시 UI가 상이하게 보여졌고 이는 사용자 관점에서는 미관상 거슬리는 요소로 판단됨 

## Changes
- div를 `container`와 Links를 감쌀 div 태그로 세분화 하여 styling을 조정함 
- 불필요한 CSS 요소 삭제(cssom 트리 구축 연산에 부하를 줄이기 위함) 
- 각 컴포넌트의 이름을 간단하게 리팩토링

## Impacts or Follow-Ups
- 해당 부분을 따로 컴포넌트로 빼서, 코드의 가독성을 높이는 작업이 요구될것으로 보임