### PR TITLE
modify: toc offest Height

### DIFF
--- a/src/components/Post/PostToc.tsx
+++ b/src/components/Post/PostToc.tsx
@@ -83,20 +83,18 @@ const PostToc: FunctionComponent<TOCProps> = function ({ headings }) {
     }
     const offsets: number[] = []
 
-    // bring each headings offsetTop
     for (const { slug } of headers) {
       const element = document.getElementById(slug)
       if (!element) {
         return
       }
-      offsets.push(element.offsetTop - 10)
+      offsets.push(element.offsetTop - 90)
     }
 
     const maxIndex = offsets.length - 1
     const { scrollY } = window
     let index = 0
 
-    // Scroll Active Trigger (looping the offset)
     if (scrollY === 0 || scrollY <= offsets[0]) {
       index = 0
     } else if (


### PR DESCRIPTION
## Backgrounds
`Introduction` 컴포넌트가 스크롤 시 90px의 뷰포트를 차지하는데, 이로 인해 TOC 에서 active 되는 구간을 수정하고 싶었음

## Changes
- 구간 설정은 `Introduction` 의 height와 제목 element가 맞닿기 직전으로 설정 (-90px)   